### PR TITLE
docs: fix YAML labels field indentation in NotificationTemplate example

### DIFF
--- a/docs/en/fuctions/email-notification.mdx
+++ b/docs/en/fuctions/email-notification.mdx
@@ -24,9 +24,9 @@ kind: NotificationTemplate
 metadata:
   name: email-compliance-report-template
   namespace: cpaas-system
-labels:
-  cpaas.io/template.email.body.type: Html
-  cpaas.io/template.language: EN
+  labels:
+    cpaas.io/template.email.body.type: Html
+    cpaas.io/template.language: EN
 spec:
   templates:
     - type: Email


### PR DESCRIPTION
## Summary
- `email-notification.mdx` 中 `NotificationTemplate` 示例的 `labels` 字段被错误地写成与 `metadata`/`spec` 同级的顶层字段
- K8s 资源的 `labels`/`annotations` 必须嵌套在 `metadata` 下,已修正为 `metadata.labels`
- 同步自 main 分支的修复 (#21)

## Test plan
- [x] 用 YAML 解析器检查代码块语法合法
- [x] 人工核对示例中字段层级与 K8s 规范一致