### PR TITLE
docs: remove legacy "microos" OS naming

### DIFF
--- a/docs/en/fuctions/email-notification.mdx
+++ b/docs/en/fuctions/email-notification.mdx
@@ -70,7 +70,7 @@ metadata:
   name: os-scan
   namespace: compliance-system
 spec:
-  profile: stig-os-microos
+  profile: stig-os-example
   scanType: node
   reportDelivery:
     email:
@@ -78,6 +78,8 @@ spec:
       recipientsRef:
         name: compliance-mail-recipients
 ```
+
+Note: `stig-os-example` is an example profile name. Use the profile names actually available in your cluster.
 
 ## Enable Email Notification for ScanSuite
 

--- a/docs/en/fuctions/quick-start.mdx
+++ b/docs/en/fuctions/quick-start.mdx
@@ -32,8 +32,10 @@ metadata:
   name: os-scan
   namespace: compliance-system
 spec:
-  profile: stig-os-microos
+  profile: stig-os-example
 ```
+
+Note: `stig-os-example` is an example profile name. Use the profile names actually available in your cluster.
 
 ### Run a ScanSuite
 

--- a/docs/en/fuctions/using-scan.mdx
+++ b/docs/en/fuctions/using-scan.mdx
@@ -13,7 +13,7 @@ Use `Scan` when you need to:
 - run one profile by itself
 - validate one target quickly without creating a batch resource
 - manage execution directly for a single compliance baseline
-- run a standalone OS scan such as `stig-os-microos`
+- run a standalone OS scan such as `stig-os-example`
 
 Use [Using ScanSuite](./scan-management.mdx) instead when you need to manage multiple profiles together or schedule repeated runs.
 
@@ -43,9 +43,11 @@ metadata:
   name: os-scan
   namespace: compliance-system
 spec:
-  profile: stig-os-microos
+  profile: stig-os-example
   scanType: node
 ```
+
+Note: `stig-os-example` is an example profile name. Use the profile names actually available in your cluster.
 
 ## Scan Parameters
 

--- a/docs/en/overview/intro.mdx
+++ b/docs/en/overview/intro.mdx
@@ -6,7 +6,7 @@ weight: 10
 
 ## What is Compliance Service?
 
-Compliance Service is a platform module designed to support STIG compliance scanning and MicroOS operating system scanning. It provides out-of-the-box compliance scanning capabilities with support for scheduled scanning and comprehensive reporting.
+Compliance Service is a platform module designed to support STIG compliance scanning and OS scanning. It provides out-of-the-box compliance scanning capabilities with support for scheduled scanning and comprehensive reporting.
 
 ## What Problems Does It Solve?
 
@@ -19,6 +19,6 @@ Compliance Service is a platform module designed to support STIG compliance scan
 
 - **Government and Defense Organizations**: Automated STIG compliance verification for DoD security requirements
 - **Enterprise Security Teams**: Regular security baseline assessments and audit preparation
-- **Cloud Infrastructure**: Compliance scanning for containerized environments and MicroOS systems
+- **Cloud Infrastructure**: Compliance scanning for containerized environments and OS systems
 - **DevSecOps Pipelines**: Integration of compliance checks into development and deployment workflows
 

--- a/docs/en/overview/release_notes.mdx
+++ b/docs/en/overview/release_notes.mdx
@@ -10,8 +10,8 @@ weight: 40
 
 - **CIS Scanning Support**: Added the ability to run CIS (Center for Internet Security) benchmark scan tasks to assess Kubernetes cluster security compliance
 - **Email Notifications**: Implemented email notification feature to automatically send scan results to specified recipients
-- **Rule ID Display**: Enhanced microos scan results to include detailed Rule ID information for better traceability
-- **Taint Tolerance**: Added support for tolerating all taints during microos scanning, allowing scans to run on nodes with any taint configuration
+- **Rule ID Display**: Enhanced OS scan results to include detailed Rule ID information for better traceability
+- **Taint Tolerance**: Added support for tolerating all taints during OS scanning, allowing scans to run on nodes with any taint configuration
 
 
 :::warning


### PR DESCRIPTION
## Summary
- CI 的 `doom-lint-no-legacy-os-names` 规则检测到文档中残留的 "microos"/"MicroOS" 命名,需要清理
- 正文描述统一改成通用的 "OS",不直接写死具体品牌名
- YAML 示例中的 `profile: stig-os-microos` 改成明显的占位符 `stig-os-example`,并加注释提示需以集群内实际可用的 profile 名称为准,避免用户误以为这是真实存在的资源名直接复制使用

## Test plan
- [x] `grep -rniI "microos" docs/` 确认无残留
- [x] `yarn lint` 本地通过(0 errors, 0 warnings)